### PR TITLE
Generate Donation Forms screen is now completed

### DIFF
--- a/src/TestData/Commands/FormSeedCommand.php
+++ b/src/TestData/Commands/FormSeedCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace GiveTestData\TestData\Commands;
+
+use WP_CLI;
+use GiveTestData\TestData\Factories\DonationFormFactory;
+use GiveTestData\TestData\Repositories\DonationFormRepository;
+
+/**
+ * Class FormSeedCommand
+ * @package GiveTestData\TestData\Commands
+ *
+ * A WP-CLI command to generate Donatoion Forms
+ */
+class FormSeedCommand {
+
+	/**
+	 * @var DonationFormFactory
+	 */
+	private $donationFormFactory;
+	/**
+	 * @var DonationFormRepository
+	 */
+	private $donationFormRepository;
+
+	public function __construct(
+		DonationFormFactory $donationFormFactory,
+		DonationFormRepository $donationFormRepository
+	) {
+		$this->donationFormFactory    = $donationFormFactory;
+		$this->donationFormRepository = $donationFormRepository;
+	}
+
+	/**
+	 * Generate Donation Forms
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--count=<count>]
+	 * : Number of donations to generate
+	 * default: 10
+	 *
+	 * [--template=<template>]
+	 * : Form template
+	 * default: random
+	 * options:
+	 *   - sequoia
+	 *   - legacy
+	 *   - random
+	 *
+	 * [--set-goal=<bool>]
+	 * : Set donation form goal
+	 * default: false
+	 *
+	 * [--set-terms=<bool>]
+	 * : Set donation form terms and conditions
+	 * default: false
+	 *
+	 * [--preview=<preview>]
+	 * : Preview generated data
+	 * default: false
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp give test-donation-form --count=10 --template=legacy --set-goal=true --set-terms=true
+	 *
+	 * @when after_wp_load
+	 */
+	public function __invoke( $args, $assocArgs ) {
+		global $wpdb;
+
+		// Get CLI args
+		$count    = WP_CLI\Utils\get_flag_value( $assocArgs, 'count', $default = 10 );
+		$preview  = WP_CLI\Utils\get_flag_value( $assocArgs, 'preview', $default = false );
+		$template = WP_CLI\Utils\get_flag_value( $assocArgs, 'template', $default = 'random' );
+		$setGoal  = WP_CLI\Utils\get_flag_value( $assocArgs, 'set-goal', $default = false );
+		$setTerms = WP_CLI\Utils\get_flag_value( $assocArgs, 'set-terms', $default = false );
+
+		// Check form template
+		if ( ! $this->donationFormFactory->checkFormTemplate( $template ) ) {
+			WP_CLI::error(
+				WP_CLI::colorize( "Unsupported form template: %g{$template}%n" )
+			);
+		}
+
+		// Factory config
+		$this->donationFormFactory->setFormTemplate( $template );
+		$this->donationFormFactory->setDonationFormGoal( $setGoal );
+		$this->donationFormFactory->setTermsAndConditions( $setTerms );
+
+		// Generate donation forms
+		$forms = $this->donationFormFactory->make( $count );
+
+		if ( $preview ) {
+			WP_CLI\Utils\format_items(
+				'table',
+				$forms,
+				array_keys( $this->donationFormFactory->definition() )
+			);
+		} else {
+			$progress = WP_CLI\Utils\make_progress_bar( 'Generating donation forms', $count );
+
+			// Start DB transaction
+			$wpdb->query( 'START TRANSACTION' );
+
+			try {
+
+				foreach ( $forms as $form ) {
+					$this->donationFormRepository->insertDonationForm( $form );
+					$progress->tick();
+				}
+
+				$wpdb->query( 'COMMIT' );
+
+				$progress->finish();
+
+			} catch ( Throwable $e ) {
+				$wpdb->query( 'ROLLBACK' );
+
+				WP_CLI::error( $e->getMessage() );
+			}
+		}
+
+	}
+
+}

--- a/src/TestData/Factories/DonationFormFactory.php
+++ b/src/TestData/Factories/DonationFormFactory.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace GiveTestData\TestData\Factories;
+
+use GiveTestData\TestData\Framework\Factory;
+
+/**
+ * Class DonationFormFactory
+ * @package GiveTestData\TestData\Factories
+ */
+class DonationFormFactory extends Factory {
+
+	/**
+	 * @var bool
+	 */
+	private $donationGoal;
+
+	/**
+	 * @var bool
+	 */
+	private $termsAndConditions;
+
+	/**
+	 * @var string
+	 */
+	private $template;
+
+	/**
+	 * @var string[]
+	 */
+	private $templates = [ 'sequoia', 'legacy' ];
+
+	/**
+	 * @param string $template
+	 *
+	 * @return bool
+	 */
+	public function checkFormTemplate( $template ) {
+		if ( 'random' === $template ) {
+			return true;
+		}
+
+		return in_array( $template, $this->templates );
+	}
+
+	/**
+	 * @param string $template
+	 */
+	public function setFormTemplate( $template ) {
+		$this->template = $template;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFormTemplate() {
+		if ( 'random' === $this->template ) {
+			return $this->randomDonationTemplate();
+		}
+
+		return $this->template;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function randomDonationTemplate() {
+		return $this->faker->randomElement( $this->templates );
+	}
+
+	/**
+	 * @param bool $generate
+	 */
+	public function setDonationFormGoal( $generate ) {
+		$this->donationGoal = ( bool ) $generate;
+	}
+
+	/**
+	 * @return false|string
+	 */
+	public function getDonationGoal() {
+		if ( is_null( $this->donationGoal ) || ! $this->donationGoal ) {
+			return false;
+		}
+
+		return $this->randomGoal();
+	}
+
+	/**
+	 * @param bool $generate
+	 */
+	public function setTermsAndConditions( $generate ) {
+		$this->termsAndConditions = ( bool ) $generate;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function getTermsAndConditions() {
+		if ( is_null( $this->termsAndConditions ) || ! $this->termsAndConditions ) {
+			return [];
+		}
+
+		return [
+			'label' => $this->faker->catchPhrase(),
+			'text'  => $this->faker->text()
+		];
+	}
+
+	/**
+	 * Donor definition
+	 *
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function definition() {
+		$title = $this->faker->catchPhrase();
+
+		return [
+			'post_title'     => $title,
+			'post_name'      => sanitize_title( $title ),
+			'post_author'    => $this->randomAuthor(),
+			'post_date'      => date( 'Y-m-d H:i:s' ),
+			'donation_goal'  => $this->getDonationGoal(),
+			'donation_terms' => $this->getTermsAndConditions(),
+			'form_template'  => $this->getFormTemplate(),
+			'random_amount'  => $this->randomAmount(),
+		];
+	}
+
+}

--- a/src/TestData/Framework/Provider/RandomGoal.php
+++ b/src/TestData/Framework/Provider/RandomGoal.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GiveTestData\TestData\Framework\Provider;
+
+class RandomGoal extends RandomProvider {
+
+	/** @var array [ int, ... ] */
+	protected $goals = [
+		1000,
+		2500,
+		5000,
+		10000,
+		25000,
+	];
+
+	public function __invoke() {
+		return $this->faker->randomElement( $this->goals );
+	}
+}

--- a/src/TestData/Repositories/DonationFormRepository.php
+++ b/src/TestData/Repositories/DonationFormRepository.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GiveTestData\TestData\Repositories;
+
+use GiveTestData\TestData\Factories\DonationFormFactory;
+use GiveTestData\TestData\Framework\MetaRepository;
+
+
+class DonationFormRepository {
+
+	/**
+	 * @var DonationFormFactory
+	 */
+	private $donationFormFactory;
+
+	public function __construct( DonationFormFactory $donationFormFactory ) {
+		$this->donationFormFactory = $donationFormFactory;
+	}
+
+	/**
+	 * @param array $form
+	 */
+	public function insertDonationForm( $form ) {
+		global $wpdb;
+
+		$form = wp_parse_args(
+			apply_filters( 'give-test-data-form-definition', $form ),
+			$this->donationFormFactory->definition()
+		);
+
+		// Insert donation
+		$wpdb->insert(
+			"{$wpdb->prefix}posts",
+			[
+				'post_type'   => 'give_forms',
+				'post_title'  => $form['post_title'],
+				'post_name'   => $form['post_name'],
+				'post_date'   => $form['post_date'],
+				'post_author' => $form['post_author'],
+				'post_status' => 'publish',
+			]
+		);
+
+		$formId = $wpdb->insert_id;
+
+		$metaRepository = new MetaRepository( 'give_formmeta', 'form_id' );
+
+		$formMeta = [
+			'_give_form_status'                                     => 'open',
+			'_give_form_template'                                   => $form['form_template'],
+			'_give_levels_minimum_amount'                           => '10.000000',
+			'_give_levels_maximum_amount'                           => '250.000000',
+			'_give_set_price'                                       => $form['random_amount'],
+			"_give_{$form['form_template']}_form_template_settings" => serialize( [
+				'introduction'        => [
+					'enabled'       => 'enabled',
+					'headline'      => $form['post_title'],
+					'description'   => 'Help our organization by donating today! All donations go directly to making a difference for our cause.',
+					'image'         => '',
+					'primary_color' => '#28C77B',
+					'donate_label'  => 'Donate Now',
+				],
+				'payment_amount'      => [
+					'header_label' => 'Choose Amount',
+					'content'      => '',
+					'next_label'   => 'Continue'
+				],
+				'payment_information' => [
+					'header_label'   => 'Add Your Information',
+					'headline'       => "Who's giving today?",
+					'description'    => 'We’ll never share this information with anyone.',
+					'checkout_label' => 'Donate Now'
+				],
+				'thank-you'           => [
+					'image'               => '',
+					'headline'            => 'A great big thank you!',
+					'description'         => '{name}, your contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}.',
+					'sharing'             => 'enabled',
+					'sharing_instruction' => 'Help us out by sharing with friends and followers that you supported the cause!',
+					'twitter_message'     => "I just gave to this cause . Who's next?"
+				]
+			] )
+		];
+
+		// Generate terms and conditions
+		if ( ! empty( $form['donation_terms'] ) ) {
+			$formMeta['_give_terms_option'] = 'enabled';
+			$formMeta['_give_agree_label']  = $form['donation_terms']['label'];
+			$formMeta['_give_agree_text']   = $form['donation_terms']['text'];
+		}
+
+		// Set donation goal
+		if ( $form['donation_goal'] ) {
+			$formMeta['_give_goal_option'] = 'enabled';
+			$formMeta['_give_goal_format'] = 'amount';
+			$formMeta['_give_set_goal']    = $form['donation_goal'];
+		}
+
+		// Insert meta
+		$metaRepository->persist( $formId, $formMeta );
+
+		do_action( 'give-test-data-insert-donation-form', $formId, $form );
+	}
+}

--- a/src/TestData/Routes/Endpoint.php
+++ b/src/TestData/Routes/Endpoint.php
@@ -27,6 +27,17 @@ abstract class Endpoint implements RestRoute {
 		return in_array( $param, array_keys( give_get_payment_statuses() ), true );
 	}
 
+
+	/**
+	 * @param string $param
+	 *
+	 * @return bool
+	 * @since 1.0.0
+	 */
+	public function validateFormTemplates( $param ) {
+		return in_array( $param, [ 'sequoia', 'legacy', 'random' ], true );
+	}
+
 	/**
 	 * @param string $param
 	 *

--- a/src/TestData/Routes/FormsRoute.php
+++ b/src/TestData/Routes/FormsRoute.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace GiveTestData\TestData\Routes;
+
+use Throwable;
+use WP_REST_Request;
+use WP_REST_Response;
+use GiveTestData\TestData\Factories\DonationFormFactory as DonationFormFactory;
+use GiveTestData\TestData\Repositories\DonationFormRepository as DonationFormRepository;
+
+/**
+ * Class FormsRoute
+ * @package GiveTestData\TestData\Routes
+ */
+class FormsRoute extends Endpoint {
+
+	/**
+	 * Maximum number of donation forms to generate per request
+	 * @var int
+	 */
+	private $limit = 30;
+
+	/** @var string */
+	protected $endpoint = 'give-test-data/generate-forms';
+
+	/**
+	 * @var DonationFormFactory
+	 */
+	private $donationFormFactory;
+
+	/**
+	 * @var DonationFormRepository
+	 */
+	private $donationFormRepository;
+
+	/**
+	 * FormsRoute constructor.
+	 *
+	 * @param DonationFormFactory $donationFormFactory
+	 * @param DonationFormRepository $donationFormRepository
+	 */
+	public function __construct(
+		DonationFormFactory $donationFormFactory,
+		DonationFormRepository $donationFormRepository
+	) {
+		$this->donationFormFactory    = $donationFormFactory;
+		$this->donationFormRepository = $donationFormRepository;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'count'      => [
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => [ $this, 'sanitizeNumber' ],
+						],
+						'template'   => [
+							'type'              => 'string',
+							'required'          => true,
+							'validate_callback' => 'validateFormTemplates',
+						],
+						'setGoal'    => [
+							'type'     => 'boolean',
+							'required' => false,
+						],
+						'generateTC' => [
+							'type'     => 'boolean',
+							'required' => false,
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ]
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-test-data',
+			'type'       => 'object',
+			'properties' => [
+				'count'      => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Number of Donation Forms to generate', 'give-test-data' ),
+				],
+				'template'   => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Donation Form template', 'give-test-data' ),
+				],
+				'setGoal'    => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Set Donation Goal', 'give-test-data' ),
+				],
+				'generateTC' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Generate Donation Terms & Conditions', 'give-test-data' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		global $wpdb;
+
+		$count    = $request->get_param( 'count' );
+		$template = $request->get_param( 'template' );
+		$setGoal  = $request->get_param( 'setGoal' );
+		$setTerms = $request->get_param( 'setTerms' );
+
+		// Check forms count and limit if necessary
+		$formsCount = ( $count > $this->limit ) ? $this->limit : $count;
+
+		// Factory config
+		$this->donationFormFactory->setFormTemplate( $template );
+		$this->donationFormFactory->setDonationFormGoal( $setGoal );
+		$this->donationFormFactory->setTermsAndConditions( $setTerms );
+
+		// Generate donation forms
+		$forms = $this->donationFormFactory->make( $formsCount );
+		// Start DB transaction
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+
+			foreach ( $forms as $form ) {
+				$this->donationFormRepository->insertDonationForm( $form );
+			}
+
+			$wpdb->query( 'COMMIT' );
+
+			$responseData = [
+				'status'  => true,
+				'hasMore' => ( $count > $this->limit )
+					? ( $count - $this->limit )
+					: 0
+			];
+
+		} catch ( Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+
+			$responseData = [
+				'status'  => false,
+				'message' => $e->getMessage()
+			];
+		}
+
+		return new WP_REST_Response( $responseData );
+	}
+
+}

--- a/src/TestData/ServiceProvider.php
+++ b/src/TestData/ServiceProvider.php
@@ -13,10 +13,12 @@ use GiveTestData\Addon\Language;
 use GiveTestData\TestData\Commands\DonorSeedCommand;
 use GiveTestData\TestData\Commands\DonationSeedCommand;
 use GiveTestData\TestData\Commands\DonationStatusCommand;
+use GiveTestData\TestData\Commands\FormSeedCommand;
 use GiveTestData\TestData\Commands\PageSeedCommand;
 use Give\ServiceProviders\ServiceProvider as GiveServiceProvider;
 use GiveTestData\TestData\Routes\DonationsRoute;
 use GiveTestData\TestData\Routes\DonorsRoute;
+use GiveTestData\TestData\Routes\FormsRoute;
 
 
 /**
@@ -49,6 +51,7 @@ class ServiceProvider implements GiveServiceProvider {
 		// Register REST routes
 		Hooks::addAction( 'rest_api_init', DonationsRoute::class, 'registerRoute' );
 		Hooks::addAction( 'rest_api_init', DonorsRoute::class, 'registerRoute' );
+		Hooks::addAction( 'rest_api_init', FormsRoute::class, 'registerRoute' );
 
 		// Load add-on translations.
 		Hooks::addAction( 'init', Language::class, 'load' );
@@ -66,5 +69,6 @@ class ServiceProvider implements GiveServiceProvider {
 		WP_CLI::add_command( 'give test-donations', give()->make( DonationSeedCommand::class ) );
 		WP_CLI::add_command( 'give test-donation-statuses', give()->make( DonationStatusCommand::class ) );
 		WP_CLI::add_command( 'give test-demonstration-page', give()->make( PageSeedCommand::class ) );
+		WP_CLI::add_command( 'give test-donation-form', give()->make( FormSeedCommand::class ) );
 	}
 }

--- a/src/TestData/resources/js/forms.js
+++ b/src/TestData/resources/js/forms.js
@@ -1,0 +1,111 @@
+import API, { CancelToken } from './api';
+// Common
+import {
+	processHasErrors,
+	updateDescription,
+	showRequestError,
+	updateProgerssBar,
+	generationStart,
+} from './utils';
+
+const { __, sprintf } = wp.i18n;
+const generateFormsBtn = document.querySelector( '#give-test-data-generate-forms' );
+
+const getData = () => {
+	return {
+		count: parseInt( document.querySelector( '#give-test-data-forms-count' ).value ),
+		template: getSelectedTemplate(),
+		setGoal: document.querySelector( '#give-test-data-forms-set-goal' ).checked,
+		setTC: document.querySelector( '#give-test-data-forms-set-tc' ).checked,
+	};
+};
+
+const getSelectedTemplate = () => {
+	const templates = document.querySelectorAll( 'input[name*="give_test_data_form_template"]:checked' );
+
+	if ( templates.length >= 2 ) {
+		return 'random';
+	}
+
+	return templates[ 0 ].value;
+};
+
+const generateForms = ( e ) => {
+	e.preventDefault();
+
+	const { count, template, setGoal, setTC } = getData();
+
+	// Check the donors count
+	if ( ! count ) {
+		// eslint-disable-next-line no-undef
+		return new Give.modal.GiveWarningAlert( {
+			modalContent: {
+				title: __( 'Enter number of forms', 'give-test-data' ),
+				desc: __( 'You must enter the number of forms to generate', 'give-test-data' ),
+				cancelBtnTitle: __( 'OK', 'give-test-data' ),
+			},
+		} ).render();
+	}
+
+	// eslint-disable-next-line no-undef
+	new Give.modal.GiveFormModal( {
+		modalContent: {
+			title: __( 'Generate Donation Forms', 'give-test-data' ),
+			desc: sprintf( __( 'Generate %s Donation Forms?', 'give-test-data' ), count ),
+			cancelBtnTitle: __( 'Close', 'give-test-data' ),
+			confirmBtnTitle: __( 'Generate', 'give-test-data' ),
+			link: '',
+			link_text: '',
+		},
+		async successConfirm() {
+			generationStart();
+
+			await generateFormsRequest( {
+				count,
+				total: count,
+				template,
+				setGoal,
+				setTC,
+			} );
+
+			if ( ! processHasErrors() ) {
+				window.location.reload( true );
+			}
+		},
+	} ).render();
+};
+
+const generateFormsRequest = ( { count, total, template, setGoal, setTC } ) => {
+	return API.post( '/generate-forms', { count, template, setGoal, setTC }, { cancelToken: CancelToken.token } )
+		.then( async( response ) => {
+			// Update description only once
+			if ( count === total ) {
+				updateDescription( __( 'Generating donation forms', 'give-test-data' ) );
+			}
+			updateProgerssBar( ( total - count ) / total * 100 );
+			// Check if it has more forms to process
+			if ( response.data.status && response.data.hasMore ) {
+				await generateFormsRequest( {
+					count: response.data.hasMore,
+					total,
+					template,
+					setGoal,
+					setTC,
+				} );
+			}
+		} )
+		.catch( ( err ) => {
+			if ( err.response ) {
+				// eslint-disable-next-line no-console
+				console.error( err.response.data );
+				showRequestError( err.response.data.message );
+			}
+
+			CancelToken.cancel();
+		} );
+};
+
+// Generate donors
+if ( generateFormsBtn ) {
+	generateFormsBtn.addEventListener( 'click', generateForms, false );
+}

--- a/src/TestData/resources/js/give-test-data-admin.js
+++ b/src/TestData/resources/js/give-test-data-admin.js
@@ -1,2 +1,3 @@
 import './donations';
 import './donors';
+import './forms';

--- a/src/TestData/resources/views/admin/forms.php
+++ b/src/TestData/resources/views/admin/forms.php
@@ -3,71 +3,71 @@
 <h3><?php esc_html_e( 'Donation Forms', 'give-test-data' ); ?></h3>
 
 <table class="give-test-data-table give-table">
-	<tbody>
-		<?php do_action( 'give-test-data-forms-start' ); ?>
+    <tbody>
+	<?php do_action( 'give-test-data-forms-start' ); ?>
 
-		<tr>
-			<td class="row-title">
-				<?php esc_html_e( 'Donation Forms count', 'give-test-data' ); ?>
-				<p><?php esc_html_e( 'Set the number of Donation Forms to generate', 'give-test-data' ); ?></p>
-			</td>
-			<td>
-				<input type="number" placeholder="10" min="1" step="1" size="4" required/>
-			</td>
-		</tr>
+    <tr>
+        <td class="row-title">
+			<?php esc_html_e( 'Donation Forms count', 'give-test-data' ); ?>
+            <p><?php esc_html_e( 'Set the number of Donation Forms to generate', 'give-test-data' ); ?></p>
+        </td>
+        <td>
+            <input type="number" id="give-test-data-forms-count" value="10" min="1" step="1" size="4" required/>
+        </td>
+    </tr>
 
-		<tr>
-			<td class="row-title">
-				<?php esc_html_e( 'Form templates', 'give-test-data' ); ?>
-				<p><?php esc_html_e( 'Set which form templates to use.', 'give-test-data' ); ?></p>
-			</td>
-			<td>
-				<label>
-					<input type="checkbox" checked/>
-					<?php esc_html_e( 'Multi-step form', 'give-test-data' ); ?>
-				</label>
+    <tr>
+        <td class="row-title">
+			<?php esc_html_e( 'Form templates', 'give-test-data' ); ?>
+            <p><?php esc_html_e( 'Set which form templates to use.', 'give-test-data' ); ?></p>
+        </td>
+        <td>
+            <label>
+                <input type="checkbox" name="give_test_data_form_template[]" value="sequoia" checked/>
+				<?php esc_html_e( 'Multi-step form', 'give-test-data' ); ?>
+            </label>
 
-				<br />
+            <br/>
 
-				<label>
-					<input type="checkbox" checked/>
-					<?php esc_html_e( 'Legacy form', 'give-test-data' ); ?>
-				</label>
-			</td>
-		</tr>
+            <label>
+                <input type="checkbox" name="give_test_data_form_template[]" value="legacy" checked/>
+				<?php esc_html_e( 'Legacy form', 'give-test-data' ); ?>
+            </label>
+        </td>
+    </tr>
 
-		<tr>
-			<td class="row-title">
-				<?php esc_html_e( 'Set Donation goal', 'give-test-data' ); ?>
-				<p> &nbsp; </p>
-			</td>
-			<td>
-				<input type="checkbox"/>
-			</td>
-		</tr>
+    <tr>
+        <td class="row-title">
+			<?php esc_html_e( 'Set Donation goal', 'give-test-data' ); ?>
+            <p> &nbsp; </p>
+        </td>
+        <td>
+            <input type="checkbox" id="give-test-data-forms-set-goal"/>
+        </td>
+    </tr>
 
-		<tr>
-			<td class="row-title">
-				<?php esc_html_e( 'Generate Form T&C', 'give-test-data' ); ?>
-				<p> &nbsp; </p>
-			</td>
-			<td>
-				<input type="checkbox"/>
-			</td>
-		</tr>
+    <tr>
+        <td class="row-title">
+			<?php esc_html_e( 'Generate Form T&C', 'give-test-data' ); ?>
+            <p> &nbsp; </p>
+        </td>
+        <td>
+            <input type="checkbox" id="give-test-data-forms-set-tc"/>
+        </td>
+    </tr>
 
-		<?php do_action( 'give-test-data-forms-end' ); ?>
+	<?php do_action( 'give-test-data-forms-end' ); ?>
 
-	</tbody>
+    </tbody>
 </table>
 
 
 <?php do_action( 'give-test-data-after-pages-table' ); ?>
 
-<br />
+<br/>
 
 <div>
-	<button class="button button-primary">
+    <button class="button button-primary" id="give-test-data-generate-forms">
 		<?php esc_html_e( 'Generate Donation Forms', 'give-test-data' ); ?>
-	</button>
+    </button>
 </div>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #8

## Description

This PR completes the Generate Donation Forms screen. Admin is now able to generate Donation Forms from Admin UI by specifying donation forms count, selecting a donation form template, and selecting to generate a random Donation goal and generate Terms & Conditions option.

## Affects

 Generate Donation Forms screen

## Visuals

![deepin-screen-recorder_Select area_20201124114343](https://user-images.githubusercontent.com/4222590/100083902-6280d500-2e4a-11eb-80e8-590275d7770b.gif)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Go to Donations -> Tools -> TestData -> Generate Donation Forms
2. Enter Donation Forms count and click on Generate button
3. Try to generate Donation Forms with multiple options enabled/disabled

