### PR TITLE
Generate Funds screen is now completed

### DIFF
--- a/src/Funds/FundsRoute.php
+++ b/src/Funds/FundsRoute.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace GiveTestData\Funds;
+
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Throwable;
+use GiveTestData\TestData\Routes\Endpoint;
+
+/**
+ * Class FundsRoute
+ * @package GiveTestData\Funds
+ */
+class FundsRoute extends Endpoint {
+
+	/**
+	 * Maximum number of donors to generate per request
+	 * @var int
+	 */
+	private $limit = 30;
+
+	/** @var string */
+	protected $endpoint = 'give-test-data/generate-funds';
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'count' => [
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => [ $this, 'sanitizeNumber' ],
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ]
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-test-data',
+			'type'       => 'object',
+			'properties' => [
+				'count' => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Number of funds to generate', 'give-test-data' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		global $wpdb;
+
+		$fundFactory    = give( FundFactory::class );
+		$fundRepository = give( FundRepository::class );
+		$count          = $request->get_param( 'count' );
+
+		// Check funds count and limit if necessary
+		$fundsCount = ( $count > $this->limit ) ? $this->limit : $count;
+		// Generate funds
+		$funds = $fundFactory->make( $fundsCount );
+		// Start DB transaction
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+
+			foreach ( $funds as $fund ) {
+				$fundRepository->insertFund( $fund );
+			}
+
+			$wpdb->query( 'COMMIT' );
+
+			$responseData = [
+				'status'  => true,
+				'hasMore' => ( $count > $this->limit )
+					? ( $count - $this->limit )
+					: 0
+			];
+
+		} catch ( Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+
+			$responseData = [
+				'status'  => false,
+				'message' => $e->getMessage()
+			];
+		}
+
+		return new WP_REST_Response( $responseData );
+	}
+
+}

--- a/src/Funds/ServiceProvider.php
+++ b/src/Funds/ServiceProvider.php
@@ -3,11 +3,12 @@
 namespace GiveTestData\Funds;
 
 use WP_CLI;
+use Give\Helpers\Hooks;
 use GiveTestData\TestData\Helpers\SettingsPage;
 use GiveTestData\Funds\AdminSettings\FundsSettings;
 use Give\ServiceProviders\ServiceProvider as GiveServiceProvider;
 
-	/**
+/**
  * Class ServiceProvider
  * @package GiveTestData\Funds
  */
@@ -38,6 +39,22 @@ class ServiceProvider implements GiveServiceProvider {
 				return $args;
 			}
 		);
+
+		/**
+		 * Load assets
+		 */
+		add_action( 'admin_enqueue_scripts', function () {
+			wp_enqueue_script(
+				'give-test-data-script-funds',
+				GIVE_TEST_DATA_URL . 'public/js/funds.js',
+				[ 'give-test-data-script-backend' ],
+				GIVE_TEST_DATA_VERSION,
+				true
+			);
+		} );
+
+		// Register REST route
+		Hooks::addAction( 'rest_api_init', FundsRoute::class, 'registerRoute' );
 
 		// Add settings section
 		SettingsPage::addPageSection( 'give-test-data', 'funds', esc_html__( 'Generate Funds', 'give-test-data' ) );

--- a/src/Funds/resources/js/funds.js
+++ b/src/Funds/resources/js/funds.js
@@ -1,0 +1,118 @@
+import API, { CancelToken } from '../../../TestData/resources/js/api';
+// Common
+import {
+	updateDescription,
+	showRequestError,
+	updateProgerssBar,
+	generationStart,
+	AppState,
+} from '../../../TestData/resources/js/utils';
+
+const { __, sprintf } = wp.i18n;
+const generateFundsBtn = document.querySelector( '#give-test-data-generate-funds' );
+// App state
+const State = new AppState( {
+	error: false,
+} );
+
+const getFundsCount = () => {
+	const input = document.querySelector( '#give-test-data-funds-count' );
+
+	if ( input ) {
+		return parseInt( input.value );
+	}
+
+	return 0;
+};
+
+const generateFunds = ( e ) => {
+	e.preventDefault();
+
+	const count = getFundsCount();
+
+	// Check the funds count
+	if ( ! count ) {
+		// eslint-disable-next-line no-undef
+		return new Give.modal.GiveWarningAlert( {
+			modalContent: {
+				title: __( 'Enter number of funds', 'give-test-data' ),
+				desc: __( 'You must enter the number of funds to generate', 'give-test-data' ),
+				cancelBtnTitle: __( 'OK', 'give-test-data' ),
+			},
+		} ).render();
+	}
+
+	// eslint-disable-next-line no-undef
+	new Give.modal.GiveFormModal( {
+		modalContent: {
+			title: __( 'Generate funds', 'give-test-data' ),
+			desc: sprintf( __( 'Generate %s funds?', 'give-test-data' ), count ),
+			cancelBtnTitle: __( 'Close', 'give-test-data' ),
+			confirmBtnTitle: __( 'Generate', 'give-test-data' ),
+			link: '',
+			link_text: '',
+		},
+		async successConfirm() {
+			generationStart( CancelToken );
+
+			await generateFundsRequest( {
+				count,
+				total: count,
+			} );
+
+			// If there is no errors, reload page
+			if ( ! State.get( 'error' ) ) {
+				window.location.reload( true );
+			}
+		},
+	} ).render();
+};
+
+const generateFundsRequest = ( { count, total } ) => {
+	return API.post( '/generate-funds', { count }, { cancelToken: CancelToken.token } )
+		.then( async( response ) => {
+			// Update description only once
+			if ( count === total ) {
+				updateDescription( __( 'Generating funds', 'give-test-data' ) );
+			}
+			// Check status
+			if ( response.data.status ) {
+				// Check if it has more forms to process
+				if ( response.data.hasMore ) {
+					updateProgerssBar( ( total - count ) / total * 100 );
+
+					await generateFundsRequest( {
+						count: response.data.hasMore,
+						total,
+					} );
+				} else {
+					updateProgerssBar( 100 );
+				}
+			} else {
+				CancelToken.cancel();
+				State.set( { error: true } );
+
+				const message = response.data.message
+					? response.data.message
+					: __( 'Something went wrong. Check the error log', 'give-test-data' );
+
+				showRequestError( message );
+			}
+		} )
+		.catch( ( err ) => {
+			CancelToken.cancel();
+			State.set( { error: true } );
+
+			if ( err.response ) {
+				// eslint-disable-next-line no-console
+				console.error( err.response.data );
+				showRequestError( err.response.data.message );
+			}
+		} );
+};
+
+// Generate donors
+if ( generateFundsBtn ) {
+	generateFundsBtn.addEventListener( 'click', generateFunds, false );
+}
+

--- a/src/Funds/resources/views/funds-table.php
+++ b/src/Funds/resources/views/funds-table.php
@@ -3,26 +3,27 @@
 <h3><?php esc_html_e( 'Funds', 'give-test-data' ); ?></h3>
 
 <table class="give-test-data-table give-table">
-	<tbody>
-		<tr>
-			<td class="row-title">
-				<?php esc_html_e( 'Funds count', 'give-test-data' ); ?>
-				<p><?php esc_html_e( 'Set the number of Funds to generate', 'give-test-data' ); ?></p>
-			</td>
-			<td>
-				<input type="number" placeholder="5" min="1" step="1" size="4" value="5" required />
-			</td>
-		</tr>
-	</tbody>
+    <tbody>
+    <tr>
+        <td class="row-title">
+			<?php esc_html_e( 'Funds count', 'give-test-data' ); ?>
+            <p><?php esc_html_e( 'Set the number of Funds to generate', 'give-test-data' ); ?></p>
+        </td>
+        <td>
+            <input id="give-test-data-funds-count" type="number" placeholder="5" min="1" step="1" size="4" value="5"
+                   required/>
+        </td>
+    </tr>
+    </tbody>
 </table>
 
 
 <?php do_action( 'give-test-data-after-funds-table' ); ?>
 
-<br />
+<br/>
 
 <div>
-	<button class="button button-primary">
+    <button id="give-test-data-generate-funds" class="button button-primary">
 		<?php esc_html_e( 'Generate Funds', 'give-test-data' ); ?>
-	</button>
+    </button>
 </div>

--- a/src/TestData/resources/js/utils.js
+++ b/src/TestData/resources/js/utils.js
@@ -1,5 +1,3 @@
-export const processHasErrors = () => document.querySelector( '.give-test-data-process-error' );
-
 export const showGenerateButton = ( show ) => {
 	// Update title
 	document
@@ -21,10 +19,20 @@ export const updateDescription = ( description ) => {
 	}
 };
 
-export const generationStart = () => {
+export const generationStart = ( CancelToken ) => {
 	showGenerateButton( false );
 	updateDescription( 'Initializing...' );
 	updateProgerssBar( 0 );
+
+	// Cancel requests if user closes the modal
+	if ( CancelToken ) {
+		document
+			.querySelector( '.give-popup-close-button' )
+			.addEventListener( 'click', function() {
+				CancelToken.cancel();
+				window.location.reload();
+			} );
+	}
 };
 
 export const showRequestError = ( error ) => {
@@ -47,3 +55,23 @@ export const updateProgerssBar = ( percent ) => {
 		element.innerHTML = `<div class="give-progress"><div style="width:${ parseInt( percent ) }%;"></div></div>`;
 	}
 };
+
+export class AppState {
+	constructor( state ) {
+		this.state = state;
+	}
+
+	set( state ) {
+		this.state = ( typeof state === 'function' )
+			? state( this.state )
+			: state;
+	}
+
+	get( key ) {
+		if ( key ) {
+			return this.state[ key ];
+		}
+
+		return this.state;
+	}
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -7,6 +7,7 @@ mix
 
 	// admin assets
 	.js( 'src/TestData/resources/js/give-test-data-admin.js', 'public/js/' )
+	.js( 'src/Funds/resources/js/funds.js', 'public/js/' )
 	.sass( 'src/TestData/resources/css/give-test-data-admin.scss', 'public/css' )
 
 	// images


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7
_Please review #9 first to avoid merge conflicts._

## Description
This PR completes the Generate Funds screen. Admin is now able to generate funds from Admin UI by selecting the number of funds to generate.

## Affects
Generate Funds screen.

## Visuals

![deepin-screen-recorder_Select area_20201124183743](https://user-images.githubusercontent.com/4222590/100131369-3b46f980-2e84-11eb-818a-1f09fdcbd93f.gif)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Go to Donations -> Tools -> TestData -> Generate Funds
2. Set the number of funds to generate and click on the Generate button
