### PR TITLE
Support to set the donation start date is not implemented

### DIFF
--- a/src/Funds/resources/js/funds.js
+++ b/src/Funds/resources/js/funds.js
@@ -1,4 +1,5 @@
 import API, { CancelToken } from '../../../TestData/resources/js/api';
+import GiveModal from '../../../TestData/resources/js/modal';
 // Common
 import {
 	updateDescription,
@@ -32,28 +33,22 @@ const generateFunds = ( e ) => {
 
 	// Check the funds count
 	if ( ! count ) {
-		// eslint-disable-next-line no-undef
-		return new Give.modal.GiveWarningAlert( {
-			modalContent: {
-				title: __( 'Enter number of funds', 'give-test-data' ),
-				desc: __( 'You must enter the number of funds to generate', 'give-test-data' ),
-				cancelBtnTitle: __( 'OK', 'give-test-data' ),
-			},
-		} ).render();
+		return new GiveModal( {
+			type: 'warning',
+			title: __( 'Enter number of funds', 'give-test-data' ),
+			content: __( 'You must enter the number of funds to generate', 'give-test-data' ),
+			cancelButton: __( 'OK', 'give-test-data' ),
+		} );
 	}
 
-	// eslint-disable-next-line no-undef
-	new Give.modal.GiveFormModal( {
-		modalContent: {
-			title: __( 'Generate funds', 'give-test-data' ),
-			desc: sprintf( __( 'Generate %s funds?', 'give-test-data' ), count ),
-			cancelBtnTitle: __( 'Close', 'give-test-data' ),
-			confirmBtnTitle: __( 'Generate', 'give-test-data' ),
-			link: '',
-			link_text: '',
-		},
-		async successConfirm() {
-			generationStart( CancelToken );
+	new GiveModal( {
+		type: 'form',
+		title: __( 'Generate funds', 'give-test-data' ),
+		content: sprintf( __( 'Generate %s funds?', 'give-test-data' ), count ),
+		cancelButton: __( 'Close', 'give-test-data' ),
+		confirmButton: __( 'Generate', 'give-test-data' ),
+		onConfirm: async() => {
+			generationStart();
 
 			await generateFundsRequest( {
 				count,
@@ -65,53 +60,55 @@ const generateFunds = ( e ) => {
 				window.location.reload( true );
 			}
 		},
-	} ).render();
+		onClose: () => {
+			CancelToken.cancel();
+			window.setTimeout( () => window.location.reload( true ), 300 );
+		},
+	} );
 };
 
 const generateFundsRequest = ( { count, total } ) => {
-	return API.post( '/generate-funds', { count }, { cancelToken: CancelToken.token } )
-		.then( async( response ) => {
-			// Update description only once
-			if ( count === total ) {
-				updateDescription( __( 'Generating funds', 'give-test-data' ) );
-			}
-			// Check status
-			if ( response.data.status ) {
-				// Check if it has more forms to process
-				if ( response.data.hasMore ) {
-					updateProgerssBar( ( total - count ) / total * 100 );
+	return API.post( '/generate-funds', { count }, { cancelToken: CancelToken.token } ).then( async( response ) => {
+		// Update description only once
+		if ( count === total ) {
+			updateDescription( __( 'Generating funds', 'give-test-data' ) );
+		}
+		// Check status
+		if ( response.data.status ) {
+			// Check if it has more forms to process
+			if ( response.data.hasMore ) {
+				updateProgerssBar( ( total - count ) / total * 100 );
 
-					await generateFundsRequest( {
-						count: response.data.hasMore,
-						total,
-					} );
-				} else {
-					updateProgerssBar( 100 );
-				}
+				await generateFundsRequest( {
+					count: response.data.hasMore,
+					total,
+				} );
 			} else {
-				CancelToken.cancel();
-				State.set( { error: true } );
-
-				const message = response.data.message
-					? response.data.message
-					: __( 'Something went wrong. Check the error log', 'give-test-data' );
-
-				showRequestError( message );
+				updateProgerssBar( 100 );
 			}
-		} )
-		.catch( ( err ) => {
+		} else {
 			CancelToken.cancel();
 			State.set( { error: true } );
 
-			if ( err.response ) {
-				// eslint-disable-next-line no-console
-				console.error( err.response.data );
-				showRequestError( err.response.data.message );
-			}
-		} );
+			const message = response.data.message
+				? response.data.message
+				: __( 'Something went wrong. Check the error log', 'give-test-data' );
+
+			showRequestError( message );
+		}
+	} ).catch( ( err ) => {
+		CancelToken.cancel();
+		State.set( { error: true } );
+
+		if ( err.response ) {
+			// eslint-disable-next-line no-console
+			console.error( err.response.data );
+			showRequestError( err.response.data.message );
+		}
+	} );
 };
 
-// Generate donors
+// Generate funds
 if ( generateFundsBtn ) {
 	generateFundsBtn.addEventListener( 'click', generateFunds, false );
 }

--- a/src/TestData/Commands/DonationSeedCommand.php
+++ b/src/TestData/Commands/DonationSeedCommand.php
@@ -65,9 +65,13 @@ class DonationSeedCommand {
 	 * : Preview generated data
 	 * default: false
 	 *
+	 * [--start-date=<date>]
+	 * : Set donation start date. Date format is YYYY-MM-DD
+	 * default: false
+	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp give test-donations --count=50 --status=random --total-revenue=10000 --currency=USD
+	 *     wp give test-donations --count=50 --status=random --total-revenue=10000 --currency=USD --start-date=2020-11-22
 	 *
 	 * @when after_wp_load
 	 */
@@ -79,6 +83,7 @@ class DonationSeedCommand {
 		$status       = WP_CLI\Utils\get_flag_value( $assocArgs, 'status', $default = 'publish' );
 		$totalRevenue = WP_CLI\Utils\get_flag_value( $assocArgs, 'total-revenue', $default = 0 );
 		$currency     = WP_CLI\Utils\get_flag_value( $assocArgs, 'currency', $default = give_get_option( 'currency' ) );
+		$startDate    = WP_CLI\Utils\get_flag_value( $assocArgs, 'start-date', $default = false );
 
 		// Check donation status
 		if ( ! $this->donationFactory->checkDonationStatus( $status ) ) {
@@ -93,6 +98,16 @@ class DonationSeedCommand {
 
 		if ( $totalRevenue ) {
 			$this->donationFactory->setDonationAmount( ( $totalRevenue / $count ) );
+		}
+
+		if ( $startDate ) {
+			if ( $this->donationFactory->isValidDate( $startDate ) ) {
+				$this->donationFactory->setDonationStartDate( $startDate );
+			} else {
+				WP_CLI::error(
+					WP_CLI::colorize( "Invalid date: %g{$startDate}%n Valid date format is YYYY-MM-DD" )
+				);
+			}
 		}
 
 		// Generate donations

--- a/src/TestData/Factories/DonationFactory.php
+++ b/src/TestData/Factories/DonationFactory.php
@@ -24,6 +24,11 @@ class DonationFactory extends Factory {
 	private $currency;
 
 	/**
+	 * @var string
+	 */
+	private $startDate;
+
+	/**
 	 * @param string $status
 	 */
 	public function setDonationStatus( $status ) {
@@ -97,6 +102,40 @@ class DonationFactory extends Factory {
 		return $this->currency;
 	}
 
+
+	/**
+	 * @param string $date
+	 */
+	public function setDonationStartDate( $date ) {
+		$this->startDate = $date;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDonationDate() {
+		if ( ! $this->isValidDate( $this->startDate ) ) {
+			return $this->faker->dateTimeThisYear()->format( 'Y-m-d H:i:s' );
+		}
+
+		return $this->faker->dateTimeBetween( $this->startDate, $endDate = 'now' )->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * @param string $date
+	 *
+	 * @return bool
+	 */
+	public function isValidDate( $date ) {
+		if ( empty( $date ) || false === strpos( $date, '-' ) ) {
+			return false;
+		}
+
+		list ( $year, $month, $day ) = explode( '-', $date );
+
+		return checkdate( $month, $day, $year );
+	}
+
 	/**
 	 * Donation definition
 	 *
@@ -115,7 +154,7 @@ class DonationFactory extends Factory {
 			'payment_mode'         => $this->randomPaymentMode(),
 			'payment_status'       => $this->getDonationStatus(),
 			'payment_purchase_key' => $this->faker->md5(),
-			'completed_date'       => $this->faker->dateTimeThisYear()->format( 'Y-m-d H:i:s' ),
+			'completed_date'       => $this->getDonationDate(),
 		];
 	}
 }

--- a/src/TestData/Factories/DonationFactory.php
+++ b/src/TestData/Factories/DonationFactory.php
@@ -3,6 +3,8 @@
 namespace GiveTestData\TestData\Factories;
 
 use GiveTestData\TestData\Framework\Factory;
+use DateTime;
+use InvalidArgumentException;
 
 /**
  * Class Donation
@@ -29,16 +31,21 @@ class DonationFactory extends Factory {
 	private $startDate;
 
 	/**
-	 * @param string $status
+	 * @param  string  $status
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function setDonationStatus( $status ) {
+		if ( ! $this->checkDonationStatus( $status ) ) {
+			throw new InvalidArgumentException( "Invalid donation status {$status}" );
+		}
 		$this->status = $status;
 	}
 
 	/**
 	 * Check is valid donation status
 	 *
-	 * @param string $status
+	 * @param  string  $status
 	 *
 	 * @return bool
 	 */
@@ -66,7 +73,7 @@ class DonationFactory extends Factory {
 	}
 
 	/**
-	 * @param int $amount
+	 * @param  int  $amount
 	 */
 	public function setDonationAmount( $amount ) {
 		$this->amount = absint( $amount );
@@ -85,7 +92,7 @@ class DonationFactory extends Factory {
 
 
 	/**
-	 * @param string $currency
+	 * @param  string  $currency
 	 */
 	public function setDonationCurrency( $currency ) {
 		$this->currency = $currency;
@@ -104,9 +111,14 @@ class DonationFactory extends Factory {
 
 
 	/**
-	 * @param string $date
+	 * @param  string  $date
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function setDonationStartDate( $date ) {
+		if ( ! $this->isValidDate( $date ) ) {
+			throw new InvalidArgumentException( "Invalid date {$date}" );
+		}
 		$this->startDate = $date;
 	}
 
@@ -122,18 +134,15 @@ class DonationFactory extends Factory {
 	}
 
 	/**
-	 * @param string $date
+	 * @param  string  $date
 	 *
 	 * @return bool
 	 */
 	public function isValidDate( $date ) {
-		if ( empty( $date ) || false === strpos( $date, '-' ) ) {
-			return false;
-		}
-
-		list ( $year, $month, $day ) = explode( '-', $date );
-
-		return checkdate( $month, $day, $year );
+		$dateTime = DateTime::createFromFormat( 'Y-m-d', $date );
+		// check dates, if one of them is different than the other, the date is not valid
+		// example: 2020-02-35 will be converted to 2020-03-06
+		return $dateTime && $dateTime->format( 'Y-m-d' ) === $date;
 	}
 
 	/**
@@ -146,8 +155,8 @@ class DonationFactory extends Factory {
 
 		return [
 			'donor_id'             => $this->randomDonor(),
-			'payment_form_id'      => $donationForm['id'],
-			'payment_form_title'   => $donationForm['post_title'],
+			'payment_form_id'      => $donationForm[ 'id' ],
+			'payment_form_title'   => $donationForm[ 'post_title' ],
 			'payment_total'        => $this->getDonationAmount(),
 			'payment_currency'     => $this->getDonationCurrency(),
 			'payment_gateway'      => $this->randomGateway(),

--- a/src/TestData/Routes/DonationsRoute.php
+++ b/src/TestData/Routes/DonationsRoute.php
@@ -113,7 +113,7 @@ class DonationsRoute extends Endpoint {
 	}
 
 	/**
-	 * @param WP_REST_Request $request
+	 * @param  WP_REST_Request  $request
 	 *
 	 * @return WP_REST_Response
 	 * @since 1.0.0
@@ -126,20 +126,30 @@ class DonationsRoute extends Endpoint {
 		$revenue   = $request->get_param( 'revenue' );
 		$startDate = $request->get_param( 'startDate' );
 
-		$this->donationFactory->setDonationStatus( $status );
+		try {
 
-		if ( $revenue ) {
-			$this->donationFactory->setDonationAmount( $revenue );
+			$this->donationFactory->setDonationStatus( $status );
+
+			if ( $revenue ) {
+				$this->donationFactory->setDonationAmount( $revenue );
+			}
+
+			if ( $startDate ) {
+				$this->donationFactory->setDonationStartDate( $startDate );
+			}
+
+			// Check donations count and limit if necessary
+			$donationsCount = ( $count > $this->limit ) ? $this->limit : $count;
+			// Generate donations
+			$donations = $this->donationFactory->make( $donationsCount );
+
+		} catch ( Throwable $e ) {
+			return new WP_REST_Response( [
+				'status'  => false,
+				'message' => $e->getMessage()
+			] );
 		}
 
-		if ( $startDate ) {
-			$this->donationFactory->setDonationStartDate( $startDate );
-		}
-
-		// Check donations count and limit if necessary
-		$donationsCount = ( $count > $this->limit ) ? $this->limit : $count;
-		// Generate donations
-		$donations = $this->donationFactory->make( $donationsCount );
 		// Start DB transaction
 		$wpdb->query( 'START TRANSACTION' );
 

--- a/src/TestData/resources/js/donors.js
+++ b/src/TestData/resources/js/donors.js
@@ -1,4 +1,5 @@
 import API, { CancelToken } from './api';
+import GiveModal from './modal';
 // Common
 import {
 	updateDescription,
@@ -32,28 +33,23 @@ const generateDonors = ( e ) => {
 
 	// Check the donors count
 	if ( ! count ) {
-		// eslint-disable-next-line no-undef
-		return new Give.modal.GiveWarningAlert( {
-			modalContent: {
-				title: __( 'Enter number of donors', 'give-test-data' ),
-				desc: __( 'You must enter the number of donors to generate', 'give-test-data' ),
-				cancelBtnTitle: __( 'OK', 'give-test-data' ),
-			},
-		} ).render();
+		return new GiveModal( {
+			type: 'warning',
+			title: __( 'Enter number of donors', 'give-test-data' ),
+			content: __( 'You must enter the number of donors to generate', 'give-test-data' ),
+			cancelButton: __( 'OK', 'give-test-data' ),
+		} );
 	}
 
 	// eslint-disable-next-line no-undef
-	new Give.modal.GiveFormModal( {
-		modalContent: {
-			title: __( 'Generate donors', 'give-test-data' ),
-			desc: sprintf( __( 'Generate %s donors?', 'give-test-data' ), count ),
-			cancelBtnTitle: __( 'Close', 'give-test-data' ),
-			confirmBtnTitle: __( 'Generate', 'give-test-data' ),
-			link: '',
-			link_text: '',
-		},
-		async successConfirm() {
-			generationStart( CancelToken );
+	new GiveModal( {
+		type: 'form',
+		title: __( 'Generate donors', 'give-test-data' ),
+		content: sprintf( __( 'Generate %s donors?', 'give-test-data' ), count ),
+		cancelButton: __( 'Close', 'give-test-data' ),
+		confirmButton: __( 'Generate', 'give-test-data' ),
+		onConfirm: async() => {
+			generationStart();
 
 			await generateDonorsRequest( {
 				count,
@@ -64,50 +60,52 @@ const generateDonors = ( e ) => {
 				window.location.reload( true );
 			}
 		},
-	} ).render();
+		onClose: () => {
+			CancelToken.cancel();
+			window.setTimeout( () => window.location.reload( true ), 300 );
+		},
+	} );
 };
 
 const generateDonorsRequest = ( { count, total } ) => {
-	return API.post( '/generate-donors', { count }, { cancelToken: CancelToken.token } )
-		.then( async( response ) => {
-			// Update description only once
-			if ( count === total ) {
-				updateDescription( __( 'Generating donors', 'give-test-data' ) );
-			}
+	return API.post( '/generate-donors', { count }, { cancelToken: CancelToken.token } ).then( async( response ) => {
+		// Update description only once
+		if ( count === total ) {
+			updateDescription( __( 'Generating donors', 'give-test-data' ) );
+		}
 
-			if ( response.data.status ) {
-				// Check if it has more donors to process
-				if ( response.data.hasMore ) {
-					updateProgerssBar( ( total - count ) / total * 100 );
+		if ( response.data.status ) {
+			// Check if it has more donors to process
+			if ( response.data.hasMore ) {
+				updateProgerssBar( ( total - count ) / total * 100 );
 
-					await generateDonorsRequest( {
-						count: response.data.hasMore,
-						total,
-					} );
-				} else {
-					updateProgerssBar( 100 );
-				}
+				await generateDonorsRequest( {
+					count: response.data.hasMore,
+					total,
+				} );
 			} else {
-				CancelToken.cancel();
-				State.set( { error: true } );
-
-				const message = response.data.message
-					? response.data.message
-					: __( 'Something went wrong. Check the error log', 'give-test-data' );
-
-				showRequestError( message );
+				updateProgerssBar( 100 );
 			}
-		} )
-		.catch( ( err ) => {
+		} else {
 			CancelToken.cancel();
 			State.set( { error: true } );
 
-			if ( err.response ) {
-				// eslint-disable-next-line no-console
-				console.error( err.response.data );
-				showRequestError( err.response.data.message );
-			}
-		} );
+			const message = response.data.message
+				? response.data.message
+				: __( 'Something went wrong. Check the error log', 'give-test-data' );
+
+			showRequestError( message );
+		}
+	} ).catch( ( err ) => {
+		CancelToken.cancel();
+		State.set( { error: true } );
+
+		if ( err.response ) {
+			// eslint-disable-next-line no-console
+			console.error( err.response.data );
+			showRequestError( err.response.data.message );
+		}
+	} );
 };
 
 // Generate donors

--- a/src/TestData/resources/js/forms.js
+++ b/src/TestData/resources/js/forms.js
@@ -1,4 +1,5 @@
 import API, { CancelToken } from './api';
+import GiveModal from './modal';
 // Common
 import {
 	updateDescription,
@@ -41,28 +42,22 @@ const generateForms = ( e ) => {
 
 	// Check the donors count
 	if ( ! count ) {
-		// eslint-disable-next-line no-undef
-		return new Give.modal.GiveWarningAlert( {
-			modalContent: {
-				title: __( 'Enter number of forms', 'give-test-data' ),
-				desc: __( 'You must enter the number of forms to generate', 'give-test-data' ),
-				cancelBtnTitle: __( 'OK', 'give-test-data' ),
-			},
-		} ).render();
+		return new GiveModal( {
+			type: 'warning',
+			title: __( 'Enter number of forms', 'give-test-data' ),
+			content: __( 'You must enter the number of forms to generate', 'give-test-data' ),
+			cancelButton: __( 'OK', 'give-test-data' ),
+		} );
 	}
 
-	// eslint-disable-next-line no-undef
-	new Give.modal.GiveFormModal( {
-		modalContent: {
-			title: __( 'Generate Donation Forms', 'give-test-data' ),
-			desc: sprintf( __( 'Generate %s Donation Forms?', 'give-test-data' ), count ),
-			cancelBtnTitle: __( 'Close', 'give-test-data' ),
-			confirmBtnTitle: __( 'Generate', 'give-test-data' ),
-			link: '',
-			link_text: '',
-		},
-		async successConfirm() {
-			generationStart( CancelToken );
+	new GiveModal( {
+		type: 'form',
+		title: __( 'Generate Donation Forms', 'give-test-data' ),
+		content: sprintf( __( 'Generate %s Donation Forms?', 'give-test-data' ), count ),
+		cancelButton: __( 'Close', 'give-test-data' ),
+		confirmButton: __( 'Generate', 'give-test-data' ),
+		onConfirm: async() => {
+			generationStart();
 
 			await generateFormsRequest( {
 				count,
@@ -76,55 +71,59 @@ const generateForms = ( e ) => {
 				window.location.reload( true );
 			}
 		},
-	} ).render();
+		onClose: () => {
+			CancelToken.cancel();
+			window.setTimeout( () => window.location.reload( true ), 300 );
+		},
+	} );
 };
 
 const generateFormsRequest = ( { count, total, template, setGoal, setTC } ) => {
-	return API.post( '/generate-forms', { count, template, setGoal, setTC }, { cancelToken: CancelToken.token } )
-		.then( async( response ) => {
-			// Update description only once
-			if ( count === total ) {
-				updateDescription( __( 'Generating donation forms', 'give-test-data' ) );
-			}
+	return API.post( '/generate-forms', {
+		count, template, setGoal, setTC,
+	}, { cancelToken: CancelToken.token } ).then( async( response ) => {
+		// Update description only once
+		if ( count === total ) {
+			updateDescription( __( 'Generating donation forms', 'give-test-data' ) );
+		}
 
-			if ( response.data.status ) {
-				// Check if it has more forms to process
-				if ( response.data.hasMore ) {
-					updateProgerssBar( ( total - count ) / total * 100 );
-					await generateFormsRequest( {
-						count: response.data.hasMore,
-						total,
-						template,
-						setGoal,
-						setTC,
-					} );
-				} else {
-					updateProgerssBar( 100 );
-				}
+		if ( response.data.status ) {
+			// Check if it has more forms to process
+			if ( response.data.hasMore ) {
+				updateProgerssBar( ( total - count ) / total * 100 );
+				await generateFormsRequest( {
+					count: response.data.hasMore,
+					total,
+					template,
+					setGoal,
+					setTC,
+				} );
 			} else {
-				CancelToken.cancel();
-				State.set( { error: true } );
-
-				const message = response.data.message
-					? response.data.message
-					: __( 'Something went wrong. Check the error log', 'give-test-data' );
-
-				showRequestError( message );
+				updateProgerssBar( 100 );
 			}
-		} )
-		.catch( ( err ) => {
+		} else {
 			CancelToken.cancel();
 			State.set( { error: true } );
 
-			if ( err.response ) {
-				// eslint-disable-next-line no-console
-				console.error( err.response.data );
-				showRequestError( err.response.data.message );
-			}
-		} );
+			const message = response.data.message
+				? response.data.message
+				: __( 'Something went wrong. Check the error log', 'give-test-data' );
+
+			showRequestError( message );
+		}
+	} ).catch( ( err ) => {
+		CancelToken.cancel();
+		State.set( { error: true } );
+
+		if ( err.response ) {
+			// eslint-disable-next-line no-console
+			console.error( err.response.data );
+			showRequestError( err.response.data.message );
+		}
+	} );
 };
 
-// Generate donors
+// Generate forms
 if ( generateFormsBtn ) {
 	generateFormsBtn.addEventListener( 'click', generateForms, false );
 }

--- a/src/TestData/resources/js/modal.js
+++ b/src/TestData/resources/js/modal.js
@@ -1,0 +1,58 @@
+const { __ } = wp.i18n;
+
+// eslint-disable-next-line no-undef
+export default class Modal extends Give.modal.GiveModal {
+	constructor( config ) {
+		const defaultConfig = {
+			type: 'confirm',
+			title: __( 'Confirm', 'give-test-data' ),
+			content: '',
+			cancelButton: __( 'Cancel', 'give-test-data' ),
+			confirmButton: __( 'OK', 'give-test-data' ),
+			link: '',
+			link_text: '',
+			onConfirm: () => {},
+			onClose: () => {},
+		};
+
+		const {
+			type,
+			onConfirm,
+			cancelButton,
+			confirmButton,
+			onClose,
+			content,
+			...modalContent
+		} = Object.assign( defaultConfig, config );
+
+		super( {
+			type,
+			modalContent: {
+				...modalContent,
+				desc: content,
+			},
+			successConfirm: onConfirm,
+			cancelBtnTitle: cancelButton,
+			confirmBtnTitle: confirmButton,
+			callbacks: {
+				afterClose: onClose,
+			},
+		} );
+
+		this.init();
+		this._setType( type );
+		this.render();
+	}
+
+	_setType( type ) {
+		switch ( type ) {
+			case 'warning':
+			case 'error':
+			case 'success':
+				this.config.classes.modalWrapper = `give-modal--${ type }`;
+				break;
+			default:
+				this.config.classes.modalWrapper = 'give-modal--notice';
+		}
+	}
+}

--- a/src/TestData/resources/js/utils.js
+++ b/src/TestData/resources/js/utils.js
@@ -1,8 +1,9 @@
 export const showGenerateButton = ( show ) => {
-	// Update title
-	document
-		.querySelector( '.give-popup-form-button' )
-		.classList.toggle( 'give-hidden', ! show );
+	const button = document.querySelector( '.give-button--primary' );
+
+	if ( button ) {
+		button.classList.toggle( 'give-hidden', ! show );
+	}
 };
 
 export const updateDescription = ( description ) => {
@@ -19,20 +20,10 @@ export const updateDescription = ( description ) => {
 	}
 };
 
-export const generationStart = ( CancelToken ) => {
+export const generationStart = () => {
 	showGenerateButton( false );
 	updateDescription( 'Initializing...' );
 	updateProgerssBar( 0 );
-
-	// Cancel requests if user closes the modal
-	if ( CancelToken ) {
-		document
-			.querySelector( '.give-popup-close-button' )
-			.addEventListener( 'click', function() {
-				CancelToken.cancel();
-				window.location.reload();
-			} );
-	}
 };
 
 export const showRequestError = ( error ) => {

--- a/src/TestData/resources/views/admin/donations.php
+++ b/src/TestData/resources/views/admin/donations.php
@@ -1,7 +1,6 @@
 <?php defined( 'ABSPATH' ) or exit; ?>
 
 <h3><?php esc_html_e( 'Donations', 'give-test-data' ); ?></h3>
-
 <table class="give-test-data-table give-table">
     <thead>
     <tr>
@@ -46,6 +45,20 @@
 	<?php endforeach; ?>
     </tbody>
 </table>
+
+<h3><?php esc_html_e( 'Set date', 'give-test-data' ); ?></h3>
+
+<table class="give-test-data-table give-table">
+    <tr>
+        <td>
+			<?php esc_html_e( 'Set the earliest donation date', 'give-test-data' ); ?>
+        </td>
+        <td>
+            <input id="give-test-data-start-date" type="date"/>
+        </td>
+    </tr>
+</table>
+
 
 <?php do_action( 'give-test-data-after-donations-table' ); ?>
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #15
_Please review #14 first to avoid merge conflicts_

## Description

This PR adds support to set the donation start date when generating donations. Currently, the donation date is randomly generated for the current year. Instead of a random date, this PR adds an option to set the "start date" which will be the earliest donations date. The donation dates will still be randomly generated, but they won't go in the past before the selected "start date".

## Affects

Generate Donations screen

## Visuals

![deepin-screen-recorder_Select area_20201126141827](https://user-images.githubusercontent.com/4222590/100355712-85e68400-2ff2-11eb-84b4-fe2fcd275844.gif)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Go to Donations -> Tools -> TestData -> Generate Donations
2. Check the status of the donation which you want to generate, enter donation count, and set the donation start date.
3.  click on the Generate button
